### PR TITLE
convert embedded relations to dot notation

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -477,6 +477,69 @@ MongoDB.prototype.parseUpdateData = function(model, data, options) {
   options = options || {};
   var parsedData = {};
 
+  var primitiveTypes = ['number', 'boolean', 'string'];
+
+  var isPrimitive = function(value) {
+    return primitiveTypes.indexOf(typeof value) !== -1 || util.isDate(value) || value === null || value.constructor && value.constructor.name === 'ObjectID';
+  };
+
+  var convertToDotNotation = function convertToDotNotation(value, modelClass) {
+    if (!value || isPrimitive(value)) {
+      return value;
+    }
+
+    var obj = {};
+
+    var flatten = function flatten(parent, prefix, child) {
+      if (!child) {
+        return;
+      }
+
+      if (isPrimitive(child)) {
+        if (!parent) {
+          parent = {};
+        }
+
+        parent[prefix] = child;
+
+        return;
+      }
+
+      var getPrefix = function getPrefix(key) {
+        if (!prefix) {
+          return key;
+        } else {
+          return prefix + '.' + key;
+        }
+      };
+
+      if (Array.isArray(child)) {
+        child.forEach(function (c, index) {
+          flatten(parent, getPrefix(index), c);
+        });
+      } else {
+        Object.keys(child).forEach(function (key) {
+          flatten(parent, getPrefix(key), child[key]);
+        });
+      }
+    };
+
+    var relations = modelClass.model.relations;
+
+
+    Object.keys(relations).forEach(function (relationName) {
+      var relation = relations[relationName],
+          embed = relation.embed,
+          keyFrom = relation.keyFrom;
+
+      if (embed) {
+        flatten(value, keyFrom, value[keyFrom]);
+        delete value[keyFrom];
+      }
+    });
+
+    return value;
+  };  
   var modelClass = this._models[model];
 
   var allowExtendedOperators = this.settings.allowExtendedOperators;
@@ -512,10 +575,10 @@ MongoDB.prototype.parseUpdateData = function(model, data, options) {
 
     // if parsedData is still empty, then we fallback to $set operator
     if (usedOperators === 0 && Object.keys(data).length > 0) {
-      parsedData.$set = data;
+      parsedData.$set = convertToDotNotation(data, modelClass);
     }
   } else if (Object.keys(data).length > 0) {
-    parsedData.$set = data;
+    parsedData.$set = convertToDotNotation(data, modelClass);
   }
 
   return parsedData;


### PR DESCRIPTION
### Description
Converts embedded relations data to dot notation for updating without overwriting current fields, eg. 

```
  strong-remoting:shared-method - __updateById__content - invoke with [ '58ba9dcf496ebba1fa53ab41',
  { statusId: 172 },
  [Function: callback] ] +0ms
  loopback:connector:mongodb before parsed { contents:
   [ { text: null,
       artisticDiscretion: 'exact',
       category: null,
       classification: null,
       contentType: 'default',
       packagedAt: null,
       deadlines: null,
       meta: null,
       dates: null,
       statusId: 172,
       action: null,
       webIONumber: null,
       webStartDate: null,
       webEndDate: null,
       webHeight: null,
       webWidth: null,
       landingUrl: null,
       animation: null,
       id: 58ba9dcf496ebba1fa53ab41,
       orderProductId: null,
       comments: [],
       files: [] } ] } +2ms
  loopback:connector:mongodb after parsed { '$set':
   { 'contents.0.artisticDiscretion': 'exact',
     'contents.0.contentType': 'default',
     'contents.0.statusId': 172,
     'contents.0.id': 58ba9dcf496ebba1fa53ab41 } } +1ms```

#### Related issues

- strongloop/loopback#2797

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
